### PR TITLE
Constructor of class PdfResponse - internal annotation removed

### DIFF
--- a/src/Joseki/Application/Responses/PdfResponse.php
+++ b/src/Joseki/Application/Responses/PdfResponse.php
@@ -297,7 +297,6 @@ class PdfResponse extends Nette\Object implements Nette\Application\IResponse
     /**
      * @param ITemplate|Template|string $source
      * @throws InvalidArgumentException
-     * @internal param
      */
     public function __construct($source)
     {


### PR DESCRIPTION
Hi,

is there some reason for "internal" annotation for constructor in PdfResponse class?
My IDE (PhpStorm) is screaming, when I am creating new instance of this class in presenters (Nette).

Thank you for your response.