### PR TITLE
allow to override mPDF showImageErrors

### DIFF
--- a/src/Joseki/Application/Responses/PdfResponse.php
+++ b/src/Joseki/Application/Responses/PdfResponse.php
@@ -434,6 +434,7 @@ class PdfResponse extends Nette\Object implements Nette\Application\IResponse
                 $margins["footer"], // float $margin_footer
                 $this->pageOrientation
             );
+            $mpdf->showImageErrors = true;
 
             $this->mPDF = $mpdf;
         }
@@ -510,7 +511,6 @@ class PdfResponse extends Nette\Object implements Nette\Application\IResponse
         $mpdf->SetAuthor($this->documentAuthor);
         $mpdf->SetTitle($this->documentTitle);
         $mpdf->SetDisplayMode($this->displayZoom, $this->displayLayout);
-        $mpdf->showImageErrors = true;
 
         // Add styles
         if (!empty($this->styles)) {


### PR DESCRIPTION
 Moved setting mpdf->showImageErrors from build() to first instantiation in getMPDF(). This way can be this option modified from outside before the actual build.
Default behaviour remains unchanged.
