### PR TITLE
AdditionalConfig - an array of parameters...

### DIFF
--- a/src/Joseki/Application/Responses/PdfResponse.php
+++ b/src/Joseki/Application/Responses/PdfResponse.php
@@ -109,6 +109,9 @@ class PdfResponse implements Nette\Application\IResponse
     /** @var string margins: top, right, bottom, left, header, footer */
     private $pageMargins = "16,15,16,15,9,9";
 
+    /** @var array aditional settings for the mPDF constuctor */
+    private $additionalConfig = [];
+
     /** @var Mpdf */
     private $mPDF = null;
 
@@ -414,6 +417,21 @@ class PdfResponse implements Nette\Application\IResponse
     }
 
 
+	/**
+	 * @param $additionalConfig Array of settings fot the mPDF constructor, see {@link https://mpdf.github.io/configuration/configuration-v7-x.html}
+	 */
+	public function setMPDFAdditionalConfig($additionalConfig)
+	{
+		if ($this->mPDF) {
+			throw new InvalidStateException('mPDF instance already created. Set additional config before calling getMPDF');
+		}
+		if (!is_array($additionalConfig)) {
+			throw new InvalidArgumentException('Additional config must be an array of settings');
+		}
+		$this->additionalConfig = $additionalConfig;
+	}
+
+
 
     /**
      * @return array
@@ -421,7 +439,7 @@ class PdfResponse implements Nette\Application\IResponse
     protected function getMPDFConfig()
     {
         $margins = $this->getMargins();
-        return [
+        return array_merge([
             'mode' => 'utf-8',
             'format' => $this->pageFormat,
             'margin_left' => $margins["left"],
@@ -431,7 +449,7 @@ class PdfResponse implements Nette\Application\IResponse
             'margin_header' => $margins["header"],
             'margin_footer' => $margins["footer"],
             'orientation' => $this->pageOrientation
-        ];
+        ], $this->additionalConfig);
     }
 
 

--- a/src/Joseki/Application/Responses/PdfResponse.php
+++ b/src/Joseki/Application/Responses/PdfResponse.php
@@ -109,8 +109,8 @@ class PdfResponse implements Nette\Application\IResponse
     /** @var string margins: top, right, bottom, left, header, footer */
     private $pageMargins = "16,15,16,15,9,9";
 
-    /** @var array aditional settings for the mPDF constuctor */
-    private $additionalConfig = [];
+    /** @var array Additional settings for the mPDF constructor */
+    private $additionalConfig = array();
 
     /** @var Mpdf */
     private $mPDF = null;


### PR DESCRIPTION
AdditionalConfig - an array of parameters that will be passed to the mPDF constructor.

Zdravím a předem varuji, že je tohle jeden z mála PR, co jsem kdy dělal.

Nové mPDF 7 má divnou vadu - nasazení DPI nemá vliv, pokud se neudělá už v jeho konstruktoru, a tak mi update na Joseki\PdfResponse v4 rozbil generování PDF – vše bylo v defaultních 96 DPI (dodatečné nastavení mPdf->dpi a mPdf->img_dpi přestalo mít vliv).
Možnost byla přidat property DPI a ImgDPI, ale kam by to časem vedlo? Namísto toho nabízím tuto jednoduchou změnu – možnost podat konstruktoru mPDF libovolné další parametry.
Sám tak budu volat $pdfResponse->setAdditionalParameters(['dpi' => 300, 'img_dpi' => 300]);

Snad je to formálně stravitelný ;-)
Díky, RgB